### PR TITLE
Set up configuration settings for PPP-RTK receiver and sets up json output from send data to sfy

### DIFF
--- a/sfy-buoy/sfy-ext-gps/ext-gps-mod/.gitignore
+++ b/sfy-buoy/sfy-ext-gps/ext-gps-mod/.gitignore
@@ -1,3 +1,6 @@
 secrets.h
 build
 *.axf
+
+# Ignore the spartn keys file since these are private codes
+spartn_keys.h

--- a/sfy-buoy/sfy-ext-gps/ext-gps-mod/ext-gps-mod.ino
+++ b/sfy-buoy/sfy-ext-gps/ext-gps-mod/ext-gps-mod.ino
@@ -1,14 +1,5 @@
 # include "ArduinoJson.h"
 # include "gps.h"
-# include "spartn_keys.h"
-
-// Serial to SFY
-// TX1: ~7 / 42
-// RX1: ~8 / 38
-// ..
-// TX1: ~9 / 39
-// RX1: ~10 / 40
-Uart sfy{1, 40, 39};
 
 void setup()
 {
@@ -17,14 +8,12 @@ void setup()
 
   setup_gps();
 
-  sfy.begin(400000);
-
-  JsonDocument doc;
-  doc["status"] = "startup";
-  serializeJson(doc, sfy);
+  // JsonDocument doc;
+  // doc["status"] = "startup";
+  // serializeJson(doc, sfy);
 
   pinMode(PPS_PIN, INPUT_PULLUP);
-  attachInterrupt(digitalPinToInterrupt(PPS_PIN), main_pps, RISING);
+  attachInterrupt(digitalPinToInterrupt(PPS_PIN), main_pps, FALLING);
 }
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
@@ -37,9 +26,9 @@ void loop()
   Serial.print(".");
   delay(100);
 
-  JsonDocument doc;
-  doc["loop"] = i;
-  serializeJson(doc, sfy);
+  // JsonDocument doc;
+  // doc["loop"] = i;
+  // serializeJson(doc, sfy);
 
   i++;
 }

--- a/sfy-buoy/sfy-ext-gps/ext-gps-mod/ext-gps-mod.ino
+++ b/sfy-buoy/sfy-ext-gps/ext-gps-mod/ext-gps-mod.ino
@@ -1,5 +1,6 @@
 # include "ArduinoJson.h"
 # include "gps.h"
+# include "spartn_keys.h"
 
 // Serial to SFY
 // TX1: ~7 / 42

--- a/sfy-buoy/sfy-ext-gps/ext-gps-mod/gps.cpp
+++ b/sfy-buoy/sfy-ext-gps/ext-gps-mod/gps.cpp
@@ -1,21 +1,226 @@
-# ifdef GPS
 # include "gps.h"
+# include "ArduinoJson.h"
 # include "spartn_keys.h"
 
-/* HardwareSerial serialGNSS(2); // ESP32 UART2: TX on 17, RX on 16 */
 SFE_UBLOX_GNSS myGNSS; // ZED-F9x
 SFE_UBLOX_GNSS myLBand; // NEO-D9S
-                        //
+
+TwoWire GnssWire(3);
+
+// Serial to SFY
+// TX1: ~7 / 42
+// RX1: ~8 / 38
+// ..
+// TX1: ~9 / 39
+// RX1: ~10 / 40
+Uart sfy{1, 40, 39};
+
+void pushRXMPMP(UBX_RXM_PMP_message_data_t *pmpData)
+{
+  //Extract the raw message payload length
+  uint16_t payloadLen = ((uint16_t)pmpData->lengthMSB << 8) | (uint16_t)pmpData->lengthLSB;
+  Serial.print(F("New RXM-PMP data received. Message payload length is "));
+  Serial.print(payloadLen);
+
+#ifndef noPush
+
+  Serial.println(F(" Bytes. Pushing it to the GNSS..."));
+  
+  //Push the PMP data to the GNSS
+  //The payload length could be variable, so we need to push the header and payload, then checksum
+  myGNSS.pushRawData(&pmpData->sync1, (size_t)payloadLen + 6); // Push the sync chars, class, ID, length and payload
+  myGNSS.pushRawData(&pmpData->checksumA, (size_t)2); // Push the checksum bytes
+
+#else
+
+  Serial.println(F(" Bytes."));
+
+#endif
+
+}
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Callback: printPVTdata will be called when new NAV PVT data arrives
+// See u-blox_structs.h for the full definition of UBX_NAV_PVT_data_t
+//         _____  You can use any name you like for the callback. Use the same name when you call setAutoPVTcallbackPtr
+//        /                  _____  This _must_ be UBX_NAV_PVT_data_t
+//        |                 /               _____ You can use any name you like for the struct
+//        |                 |              /
+//        |                 |              |
+void printPVTdata(UBX_NAV_PVT_data_t *ubxDataStruct)
+{
+  // Time from GNSS Solution (UTC)
+  uint16_t year = ubxDataStruct->year;
+  uint8_t month = ubxDataStruct->month;
+  uint8_t day = ubxDataStruct->day;
+  uint8_t hour = ubxDataStruct->hour;
+  uint8_t minute = ubxDataStruct->min;
+  uint8_t sec = ubxDataStruct->sec;
+  int32_t nano = ubxDataStruct->nano;
+  String datetime = String(year) + "-" + String(month) + "-" + String(day) + ":" + String(hour) + ":" + String(minute) + ":" + String(sec) + "." + String(nano);
+  Serial.print(F("Time: "));
+  Serial.println(datetime);
+
+  double tAcc = ubxDataStruct->tAcc;
+  Serial.print(F("  Time accuracy (ns): "));
+  Serial.println(tAcc);
+
+  double latitude = ubxDataStruct->lat; // Print the latitude
+  Serial.print(F("  Lat: "));
+  Serial.print(latitude / 10000000.0, 7);
+
+  double longitude = ubxDataStruct->lon; // Print the longitude
+  Serial.print(F("  Long: "));
+  Serial.print(longitude / 10000000.0, 7);
+
+  double altitude = ubxDataStruct->hMSL; // Print the height above mean sea level
+  Serial.print(F("  Height: "));
+  Serial.print(altitude / 1000.0, 3);
+
+  uint8_t fixType = ubxDataStruct->fixType; // Print the fix type
+  Serial.print(F("  Fix: "));
+  Serial.print(fixType);
+  if (fixType == 0)
+    Serial.print(F(" (None)"));
+  else if (fixType == 1)
+    Serial.print(F(" (Dead Reckoning)"));
+  else if (fixType == 2)
+    Serial.print(F(" (2D)"));
+  else if (fixType == 3)
+    Serial.print(F(" (3D)"));
+  else if (fixType == 4)
+    Serial.print(F(" (GNSS + Dead Reckoning)"));
+  else if (fixType == 5)
+    Serial.print(F(" (Time Only)"));
+  else
+    Serial.print(F(" (UNKNOWN)"));
+
+  uint8_t carrSoln = ubxDataStruct->flags.bits.carrSoln; // Print the carrier solution
+  Serial.print(F("  Carrier Solution: "));
+  Serial.print(carrSoln);
+  if (carrSoln == 0)
+    Serial.print(F(" (None)"));
+  else if (carrSoln == 1)
+    Serial.print(F(" (Floating)"));
+  else if (carrSoln == 2)
+    Serial.print(F(" (Fixed)"));
+  else
+    Serial.print(F(" (UNKNOWN)"));
+
+  uint32_t hAcc = ubxDataStruct->hAcc; // Print the horizontal accuracy estimate
+  Serial.print(F("  Horizontal Accuracy Estimate: "));
+  Serial.print(hAcc);
+  Serial.print(F(" (mm)"));
+
+  uint32_t vAcc = ubxDataStruct->vAcc; // Print the horizontal accuracy estimate
+  Serial.print(F("  Vertical Accuracy Estimate: "));
+  Serial.print(vAcc);
+  Serial.print(F(" (mm)"));
+
+  Serial.println(); 
+
+  // Serialize Data and Pipe to SFY 
+  JsonDocument doc;
+  doc["Time (UTC)"] = datetime;
+  doc["Time Accuracy (ns)"] = tAcc;
+  doc["Lat (deg * 10e-7)"] = latitude;
+  doc["Lon (deg * 10e-7)"] = longitude;
+  doc["Height above MSL(mm)"] = altitude;
+  doc["Horizontal Accuracy (mm)"] = hAcc;
+  doc["Vertical Accuracy (mm)"] = vAcc;
+  doc["Carrier Soln"] = carrSoln;
+  doc["Fix Type"] = fixType;
+  serializeJson(doc, sfy);
+  sfy.println();
+}
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+// Callback: printRXMCOR will be called when new RXM COR data arrives
+// See u-blox_structs.h for the full definition of UBX_RXM_COR_data_t
+//         _____  You can use any name you like for the callback. Use the same name when you call setRXMCORcallbackPtr
+//        /                  _____  This _must_ be UBX_RXM_COR_data_t
+//        |                 /               _____ You can use any name you like for the struct
+//        |                 |              /
+//        |                 |              |
+void printRXMCOR(UBX_RXM_COR_data_t *ubxDataStruct)
+{
+  Serial.print(F("UBX-RXM-COR:  ebno: "));
+  Serial.print((double)ubxDataStruct->ebno / 8, 3); //Convert ebno to dB
+
+  Serial.print(F("  protocol: "));
+  if (ubxDataStruct->statusInfo.bits.protocol == 1)
+    Serial.print(F("RTCM3"));
+  else if (ubxDataStruct->statusInfo.bits.protocol == 2)
+    Serial.print(F("SPARTN"));
+  else if (ubxDataStruct->statusInfo.bits.protocol == 29)
+    Serial.print(F("PMP (SPARTN)"));
+  else if (ubxDataStruct->statusInfo.bits.protocol == 30)
+    Serial.print(F("QZSSL6"));
+  else
+    Serial.print(F("Unknown"));
+
+  Serial.print(F("  errStatus: "));
+  if (ubxDataStruct->statusInfo.bits.errStatus == 1)
+    Serial.print(F("Error-free"));
+  else if (ubxDataStruct->statusInfo.bits.errStatus == 2)
+    Serial.print(F("Erroneous"));
+  else
+    Serial.print(F("Unknown"));
+
+  Serial.print(F("  msgUsed: "));
+  if (ubxDataStruct->statusInfo.bits.msgUsed == 1)
+    Serial.print(F("Not used"));
+  else if (ubxDataStruct->statusInfo.bits.msgUsed == 2)
+    Serial.print(F("Used"));
+  else
+    Serial.print(F("Unknown"));
+
+  Serial.print(F("  msgEncrypted: "));
+  if (ubxDataStruct->statusInfo.bits.msgEncrypted == 1)
+    Serial.print(F("Not encrypted"));
+  else if (ubxDataStruct->statusInfo.bits.msgEncrypted == 2)
+    Serial.print(F("Encrypted"));
+  else
+    Serial.print(F("Unknown"));
+
+  Serial.print(F("  msgDecrypted: "));
+  if (ubxDataStruct->statusInfo.bits.msgDecrypted == 1)
+    Serial.print(F("Not decrypted"));
+  else if (ubxDataStruct->statusInfo.bits.msgDecrypted == 2)
+    Serial.print(F("Successfully decrypted"));
+  else
+    Serial.print(F("Unknown"));
+
+  Serial.println();
+}
+
+
+void pps() {
+  // pps pulse interrupt: should be triggered at the start of every gps second.
+  // pps_ts = micros();
+
+  Serial.println("GNSS: PPS!");
+  myGNSS.checkUblox(); // Check for the arrival of new GNSS data and process it.
+  myGNSS.checkCallbacks(); // Check if any GNSS callbacks are waiting to be processed.
+
+  myLBand.checkUblox(); // Check for the arrival of new PMP data and process it.
+  myLBand.checkCallbacks(); // Check if any LBand callbacks are waiting to be processed.
+
+}
+                  
 void setup_gps() {
-  serialGNSS.begin(38400); // UART2 on pins 16/17 for SPP. The ZED-F9P will be configured to use the same rate.
-  Wire.begin(); //Start I2C
+
+  sfy.begin(400000);
+
+  // serialGNSS.begin(38400); // UART2 on pins 16/17 for SPP. The ZED-F9P will be configured to use the same rate.
+  // Wire.begin(); //Start I2C
+  GnssWire.begin();
 
   //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   // Begin and configure the ZED-F9x
 
-  //myGNSS.enableDebugging(); // Uncomment this line to enable helpful debug messages on Serial
+  // myGNSS.enableDebugging(); // Uncomment this line to enable helpful debug messages on Serial
 
-  while (myGNSS.begin() == false) //Connect to the u-blox module using Wire port
+  while (myGNSS.begin(GnssWire) == false) //Connect to the u-blox module using Wire port
   {
     Serial.println(F("u-blox GNSS module not detected at default I2C address. Please check wiring."));
     delay(2000);
@@ -45,25 +250,59 @@ void setup_gps() {
     Serial.println(F("Error: could not read module info!"));
 
   uint8_t ok = myGNSS.setI2COutput(COM_TYPE_UBX); //Turn off NMEA noise
-  if (ok) ok = myGNSS.setI2CInput(COM_TYPE_UBX);
-  if (ok) ok = myGNSS.setUART1Output(0);
-  if (ok) ok = myGNSS.setUART1Input(0);
-  if (ok) ok = myGNSS.setUART2Output(0);
-  if (ok) ok = myGNSS.setUART2Input(COM_TYPE_UBX | COM_TYPE_NMEA | COM_TYPE_SPARTN); //Be sure SPARTN input is enabled
-  if (ok) ok = myGNSS.setDGNSSConfiguration(SFE_UBLOX_DGNSS_MODE_FIXED); // Set the differential mode - ambiguities are fixed whenever possible
-  if (ok) ok = myGNSS.setNavigationFrequency(20); //Set output in Hz.
-  if (ok) ok = myGNSS.setVal8(UBLOX_CFG_SPARTN_USE_SOURCE, 1); // Set to 1 for using L-Band Correction
-  if (ok) ok = myGNSS.setVal8(UBLOX_CFG_MSGOUT_UBX_RXM_COR_I2C, 1); // Enable UBX-RXM-COR messages on I2C
-  if (ok) ok = myGNSS.setVal8(UBX_NAV_PVT, 1);
+  Serial.println(OK(ok));
+  ok = myGNSS.setI2CInput(COM_TYPE_UBX);
+  Serial.println(OK(ok));
+  ok = myGNSS.setUART1Output(0);
+  Serial.println(OK(ok));
+  ok = myGNSS.setUART1Input(0);
+  Serial.println(OK(ok));
+  ok = myGNSS.setUART2Output(0);
+  Serial.println(OK(ok));
+  ok = myGNSS.setUART2Input(COM_TYPE_UBX | COM_TYPE_NMEA | COM_TYPE_SPARTN); //Be sure SPARTN input is enabled
+  Serial.println(OK(ok));
+  ok = myGNSS.setDGNSSConfiguration(SFE_UBLOX_DGNSS_MODE_FIXED); // Set the differential mode - ambiguities are fixed whenever possible
+  Serial.println(OK(ok));
+  ok = myGNSS.setNavigationFrequency(20); //Set output in Hz.
+  Serial.println(OK(ok));
+  ok = myGNSS.setVal8(UBLOX_CFG_SPARTN_USE_SOURCE, 1); // Set to 1 for using L-Band Correction
+  Serial.println(OK(ok));
+  ok = myGNSS.setVal8(UBLOX_CFG_MSGOUT_UBX_RXM_COR_I2C, 1); // Enable UBX-RXM-COR messages on I2C
+  Serial.println(OK(ok));
+  ok = myGNSS.setVal8(UBX_NAV_PVT, 1);
+
+  // Configure the Timing Pulse settings
+  myGNSS.newCfgValset(VAL_LAYER_RAM); // Create a new Configuration Interface VALSET message. Apply the changes in RAM only (not BBR).
+  // Let's say that we want our 1 pulse every 30 seconds to be as accurate as possible. So, let's tell the module
+  // to generate no signal while it is _locking_ to GNSS time. We want the signal to start only when the module is
+  // _locked_ to GNSS time.
+  myGNSS.addCfgValset(UBLOX_CFG_TP_PERIOD_TP1, 0); 
+  myGNSS.addCfgValset(UBLOX_CFG_TP_LEN_TP1, 0); // Set the pulse length to zero
   
+  // When the module is _locked_ to GNSS time, make it generate a  second pulse every 30 seconds
+  // myGNSS.addCfgValset(UBLOX_CFG_TP_PERIOD_LOCK_TP1, 50000); // Set the period to 30,000,000 us
+  // myGNSS.addCfgValset(UBLOX_CFG_TP_LEN_LOCK_TP1, 10000); // Set the pulse length to 1,000,000 us
+  myGNSS.addCfgValset(UBLOX_CFG_TP_PERIOD_LOCK_TP1, 1000000); // Set the period to 30,000,000 us
+  myGNSS.addCfgValset(UBLOX_CFG_TP_LEN_LOCK_TP1, 100000); // Set the pulse length to 1,000,000 us
+  
+  // Now set the time pulse parameters
+  if (myGNSS.sendCfgValset() == false)
+  {
+    Serial.println(F("VALSET failed!"));
+  }
+  else
+  {
+    Serial.println(F("Success!"));
+  }
+
   //Configure the SPARTN IP Dynamic Keys
   //"When the receiver boots, the host should send 'current' and 'next' keys in one message." - Use setDynamicSPARTNKeys for this.
   //"Every time the 'current' key is expired, 'next' takes its place."
   //"Therefore the host should then retrieve the new 'next' key and send only that." - Use setDynamicSPARTNKey for this.
   // The key can be provided in binary (uint8_t) format or in ASCII Hex (char) format, but in both cases keyLengthBytes _must_ represent the binary key length in bytes.
-  if (ok) ok = myGNSS.setDynamicSPARTNKeys(currentKeyLengthBytes, currentKeyGPSWeek, currentKeyGPSToW, currentDynamicKey,
+  ok = myGNSS.setDynamicSPARTNKeys(currentKeyLengthBytes, currentKeyGPSWeek, currentKeyGPSToW, currentDynamicKey,
                                            nextKeyLengthBytes, nextKeyGPSWeek, nextKeyGPSToW, nextDynamicKey);
-
+  Serial.println(OK(ok));
   //if (ok) ok = myGNSS.saveConfiguration(VAL_CFG_SUBSEC_IOPORT | VAL_CFG_SUBSEC_MSGCONF); //Optional: Save the ioPort and message settings to NVM and BBR
 
   Serial.print(F("GNSS: configuration "));
@@ -78,7 +317,7 @@ void setup_gps() {
 
   //myLBand.enableDebugging(); // Uncomment this line to enable helpful debug messages on Serial
 
-  while (myLBand.begin(Wire, 0x43) == false) //Connect to the u-blox NEO-D9S using Wire port. The D9S default I2C address is 0x43 (not 0x42)
+  while (myLBand.begin(GnssWire, 0x43) == false) //Connect to the u-blox NEO-D9S using Wire port. The D9S default I2C address is 0x43 (not 0x42)
   {
     Serial.println(F("u-blox NEO-D9S not detected at default I2C address. Please check wiring."));
     delay(2000);
@@ -104,7 +343,7 @@ void setup_gps() {
   myLBand.addCfgValset(UBLOX_CFG_UART2OUTPROT_UBX,         1);           // Enable UBX output on UART2
   myLBand.addCfgValset(UBLOX_CFG_MSGOUT_UBX_RXM_PMP_UART2, 1);           // Output UBX-RXM-PMP on UART2
   myLBand.addCfgValset(UBLOX_CFG_UART2_BAUDRATE,           38400);       // match baudrate with ZED default
-  uint8_t ok = myLBand.sendCfgValset(); // Apply the settings
+  ok = myLBand.sendCfgValset(); // Apply the settings
 
   Serial.print(F("L-Band: configuration "));
   Serial.println(OK(ok));
@@ -115,11 +354,9 @@ void setup_gps() {
 }
 
 void loop_gps() {
-  myGNSS.checkUblox(); // Check for the arrival of new GNSS data and process it.
-  myGNSS.checkCallbacks(); // Check if any GNSS callbacks are waiting to be processed.
+  // myGNSS.checkUblox(); // Check for the arrival of new GNSS data and process it.
+  // myGNSS.checkCallbacks(); // Check if any GNSS callbacks are waiting to be processed.
 
-  myLBand.checkUblox(); // Check for the arrival of new PMP data and process it.
-  myLBand.checkCallbacks(); // Check if any LBand callbacks are waiting to be processed.
+  // myLBand.checkUblox(); // Check for the arrival of new PMP data and process it.
+  // myLBand.checkCallbacks(); // Check if any LBand callbacks are waiting to be processed.
 }
-
-# endif

--- a/sfy-buoy/sfy-ext-gps/ext-gps-mod/gps.h
+++ b/sfy-buoy/sfy-ext-gps/ext-gps-mod/gps.h
@@ -1,10 +1,8 @@
+# define GPS
 # ifndef GPS_H
 # define GPS_H
 # include <SparkFun_u-blox_GNSS_v3.h> //http://librarymanager/All#SparkFun_u-blox_GNSS_v3
-#include <vector>
-                                      //
-//const uint32_t myLBandFreq = 1556290000; // Uncomment this line to use the US SPARTN 1.8 service
-//const uint32_t myLBandFreq = 1545260000; // Uncomment this line to use the EU SPARTN 1.8 service
+# include <vector>
 
 #define OK(ok) (ok ? F("  ->  OK") : F("  ->  ERROR!")) // Convert uint8_t into OK/ERROR
 


### PR DESCRIPTION
**Overview:** This update adds all configuration settings to the PPP-RTK receiver and also sets up the json document that will send data to the sfy from the receiver. The data sent to the SFY includes: Time (UTC), time accuracy (ns), lat, lon, height above mean sea level (geoid, WGS84 in mm), horizontal accuracy (mm), vertical accuracy (mm), carrier solution, and gps fix type. 

**Next Steps:** 

- adjust the navigation solution frequency to 20 Hz, it is currently set to 1 Hz for easy testing
- need to set up another json document to output the correction data, it might be useful to have later on as well in case there is an issue with integrating it realtime

**Other Notes:**

- the SPARTN keys file is ignored in the repository, so the decryption keys are not available to the public
